### PR TITLE
Correct optional SST block handle semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@
   left this implicit).
 
 ### Corrected (the earlier text was wrong, not merely unconfirmed)
+- `format/sst.md` §5.1/§6/§7 — corrected the optional-block-handle presence rule.
+  The earlier text classified `(offset = 0, size > 0)` as half-present corruption,
+  but offset 0 is the valid location of the first block in an SST. `(0, 0)` remains
+  the absent sentinel; any positive size is present at any offset; only a positive
+  offset paired with zero size is a partially present handle. This is a reader-side
+  compatibility correction and does not change wire bytes.
 - `format/wal.md` §6.4 point 3 — this document previously stated that epoch-mixing
   within one physical WAL file is corruption. That directly contradicts this
   format's own append-on-reopen recovery model: the active file is never rotated at

--- a/format/sst.md
+++ b/format/sst.md
@@ -303,8 +303,14 @@ Every block in the file — data, range-tombstone, trie, block-bloom, meta, and 
 The `BlockHandle` recorded for this block (in the index block or the footer) uses:
 
 - `offset`: the file offset of the 4-byte `payload_len` field itself (i.e. the start
-  of the wrapper, not the start of the compressed payload).
+  of the wrapper, not the start of the compressed payload). Offset 0 is valid: it
+  means the block is the first block in the file.
 - `size`: `4 + payload_len` — the *total* wrapper size, length prefix included.
+
+For an optional handle, the pair `(offset = 0, size = 0)` is the sole absent
+sentinel. Any handle with `size > 0` is present, including `(offset = 0, size > 0)`.
+The pair `(offset > 0, size = 0)` is corruption. A reader must not interpret a zero
+offset alone as absence or corruption.
 
 A reader validates a handle by checking `offset + size <= block_region_end` — where
 `block_region_end` is the footer's own starting offset, i.e. the end of everything
@@ -349,7 +355,7 @@ little-endian:
 | `index_kind` | u8 | `0` = `Sparse` (full binary index, §4.1 only), `1` = `Trie` (index block **and** trie block both present, §4.2). Any other value is corruption. |
 | `flags` | u8 | Bit 0: key-range metadata present (§6.1). All other bits must be zero; a nonzero unknown bit is corruption, not a silently-ignored future extension. |
 | *(reserved)* | 2 bytes | Must be zero. |
-| `range_tombstone_handle` | 16 bytes (`offset` u64 + `size` u64) | `BlockHandle` for the range-tombstone block (§8), or all-zero if this SST carries no range tombstones. Half-present (nonzero size with zero offset, or zero size with nonzero offset) is corruption — the pair must be fully present or fully absent. |
+| `range_tombstone_handle` | 16 bytes (`offset` u64 + `size` u64) | `BlockHandle` for the range-tombstone block (§8), or all-zero if this SST carries no range tombstones. Presence follows §5.1: a positive size is present even at offset 0; a positive offset with zero size is corruption. |
 | *(key-range, only if flag bit 0 set)* | variable | See §6.1. |
 
 If the key-range flag is clear, the meta block must end exactly at the fixed 24-byte
@@ -391,6 +397,10 @@ of the file:
 Total footer size: **84 bytes**, always, regardless of which optional handles are
 populated (unused handles are zero-filled, not omitted — the footer never changes
 length).
+
+The optional `trie_handle` and `block_bloom_handle` use §5.1's presence rule:
+`(0, 0)` is absent, a positive `size` is present at any `offset`, and a positive
+`offset` paired with zero `size` is corruption.
 
 ### 7.1 Locating the index from EOF
 

--- a/notes/implementation-findings.md
+++ b/notes/implementation-findings.md
@@ -137,6 +137,26 @@ value length is valid and round-trippable. Both the rule and the finding against
 engine R were withdrawn; `format/sst.md` §3.2 now states the minimal writer
 requirement that follows from the reader's check.
 
+### 2.3 Optional SST block handles at file offset zero
+
+An earlier draft treated both `(offset = 0, size > 0)` and
+`(offset > 0, size = 0)` as partially present optional handles. The first form is
+not intrinsically partial: offset 0 is the valid start of the first block in an SST.
+
+Engine R demonstrates the compatibility consequence with a tombstone-only SST. It
+writes the range-tombstone block before any footer or index structures, so that
+block legitimately has offset 0 and a positive size. Enforcing the earlier rule
+made the reader reject SSTs produced by its own writer and broke compaction and
+cloud-recovery tests.
+
+Engine C writes its block Bloom filter first, preventing its own range-tombstone
+writer from producing an offset-0 handle. Its footer optional-handle decoder already
+accepts offset 0 with a positive size, while its range-tombstone metadata decoder is
+stricter. The corrected rule uses the wire pair's unambiguous semantics rather than
+a writer-specific block order: `(0, 0)` is absent, positive size is present at any
+offset, and positive offset with zero size is corruption. No wire bytes change; the
+correction broadens readers to accept a valid first-block placement.
+
 ## 3. Facts established by cross-implementation agreement
 
 These were confirmed in both engines' source and are stated as plain requirements in


### PR DESCRIPTION
## Summary

Correct the optional SST `BlockHandle` presence rule: `(0, 0)` is absent, any positive size is present at any offset, and only a positive offset paired with zero size is partially present corruption.

## Rationale

The earlier symmetric half-present rule incorrectly treated file offset 0 as reserved. Offset 0 is the legitimate start of the first SST block, and Midge emits a range-tombstone block there for tombstone-only SSTs. Enforcing the old text made a reader reject valid output from its own writer.

The normative format, changelog, and non-normative implementation findings now record the rule, evidence, and compatibility impact. This resolves the false premise reported in cntryl/midge#248.

## Compatibility impact

This is a reader-side compatibility correction with no wire-byte change. Conforming readers accept a valid optional first-block placement; `(offset > 0, size = 0)` remains corruption and `(0, 0)` remains absent.

## Validation

- `jq empty schema/*.json`
- `git diff --check`
- `rg -n "TODO: verify" format/` reviewed; no new unresolved question introduced

## Tool assistance disclosure

Codex assisted with the implementation cross-check, specification edit, and validation.